### PR TITLE
Update Rom List for a mistake in title label

### DIFF
--- a/Nitrogen/roms/NitrogenROMTableViewController.m
+++ b/Nitrogen/roms/NitrogenROMTableViewController.m
@@ -123,7 +123,7 @@
         // use title from ROM
         NSArray *titleLines = [game.gameTitle componentsSeparatedByString:@"\n"];
         cell.textLabel.text = titleLines[0];
-        cell.detailTextLabel.text = titleLines.count >= 1 ? titleLines[1] : nil;
+        cell.detailTextLabel.text = titleLines.count > 1 ? titleLines[1] : nil;
     } else {
         // use filename
         cell.textLabel.text = game.title;


### PR DESCRIPTION
Fix a bug:
When the iOS is setting to Chinese language, "Nitrogen"( or previous named "nds4ios")  would crash when there is a 256MB NDS ROM in the list. (e.g. Pokemon Black/White Black2/White2)
修正一个bug：
当Nitrogen(原来的nds4ios)运行在中文iOS时，而且应用里面有256MB的NDS NOM（比如 口袋妖怪 黑白、黑白2），进入应用会闪退。