### PR TITLE
Add "Synch Audio" setting, fix iPhone6/6+ resolution support

### DIFF
--- a/Nitrogen/MainStoryboard.storyboard
+++ b/Nitrogen/MainStoryboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="RwU-Ga-Til">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C94b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="RwU-Ga-Til">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <scenes>
         <!--Settings-->
@@ -24,7 +24,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="2i9-9X-BIw">
-                                                    <rect key="frame" x="20" y="36.5" width="280" height="29"/>
+                                                    <rect key="frame" x="20" y="36" width="280" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                     <segments>
                                                         <segment title="0"/>
@@ -75,6 +75,32 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="QLs-gO-KDW">
+                                        <rect key="frame" x="0.0" y="237" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QLs-gO-KDW" id="nNm-OB-6pH">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="c1F-hA-v70">
+                                                    <rect key="frame" x="251" y="6" width="51" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                    <color key="onTintColor" red="0.2588235438" green="0.75294125079999996" blue="0.98431378599999997" alpha="1" colorSpace="deviceRGB"/>
+                                                    <connections>
+                                                        <action selector="controlChanged:" destination="c3c-6p-wCh" eventType="valueChanged" id="fXh-EH-p2n"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Synchronous Audio" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="O1f-2K-M0t">
+                                                    <rect key="frame" x="17" y="11" width="175" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="highlightedColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="9Hh-4E-N3U">
                                         <rect key="frame" x="0.0" y="237" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
@@ -113,7 +139,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="Aa4-Hv-ujp">
-                                                    <rect key="frame" x="20" y="36.5" width="279" height="29"/>
+                                                    <rect key="frame" x="20" y="36" width="279" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                     <segments>
                                                         <segment title="D-Pad"/>
@@ -142,7 +168,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="WTS-jQ-bi4">
-                                                    <rect key="frame" x="20" y="36.5" width="280" height="29"/>
+                                                    <rect key="frame" x="20" y="36" width="280" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                     <segments>
                                                         <segment title="Top"/>
@@ -348,6 +374,8 @@
                         <outlet property="showFPSSwitch" destination="hjj-DU-8Z8" id="oa2-4w-1fP"/>
                         <outlet property="showPixelGridLabel" destination="i1H-5W-GBv" id="4w0-2q-gTw"/>
                         <outlet property="showPixelGridSwitch" destination="U7N-Jx-IWl" id="do9-tv-emX"/>
+                        <outlet property="synchSoundLabel" destination="O1f-2K-M0t" id="6t9-uM-Jhe"/>
+                        <outlet property="synchSoundSwitch" destination="c1F-hA-v70" id="sJA-h1-gfc"/>
                         <outlet property="vibrateLabel" destination="cNL-IT-Ar0" id="1CC-ba-efi"/>
                         <outlet property="vibrateSwitch" destination="bp0-zJ-1yS" id="Fh5-fN-3Jp"/>
                     </connections>
@@ -414,9 +442,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="center" image="pixelgrid.png" id="DP7-yE-vFs">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" image="pixelgrid.png" id="DP7-yE-vFs">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </imageView>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="60 FPS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mo4-qa-NUQ">
                                 <rect key="frame" x="7" y="0.0" width="70" height="24"/>
@@ -589,7 +617,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.9" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="0Ib-Ge-gJv">
-                                                    <rect key="frame" x="96.00000020800627" y="0.0" width="215" height="43"/>
+                                                    <rect key="frame" x="96.000000434598491" y="0.0" width="215" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="highlightedColor"/>

--- a/Nitrogen/core/emu.cpp
+++ b/Nitrogen/core/emu.cpp
@@ -23,6 +23,7 @@
 #include "cheatSystem.h"
 #include "slot1.h"
 #include "version.h"
+#include "metaspu.h"
 
 #define LOGI(...) printf(__VA_ARGS__);printf("\n")
 
@@ -292,6 +293,15 @@ void EMU_change3D(int type)
 void EMU_changeSound(int type)
 {
 	SPU_ChangeSoundCore(type, DESMUME_SAMPLE_RATE*8/60);
+}
+
+void EMU_setSynchMode(bool enabled)
+{
+    if (enabled == true) {
+        SPU_SetSynchMode(ESynchMode_Synchronous,ESynchMethod_N);
+    } else {
+        SPU_SetSynchMode(ESynchMode_DualSynchAsynch,ESynchMethod_N);
+    }
 }
 
 void EMU_enableSound(bool enabled)

--- a/Nitrogen/core/emu.h
+++ b/Nitrogen/core/emu.h
@@ -37,6 +37,7 @@ void EMU_changeSound(int type);
 void EMU_enableSound(bool enable);
 void EMU_setFrameSkip(int skip);
 void EMU_setCPUMode(int cpuMode);
+void EMU_setSynchMode(bool enabled);
 void EMU_runCore();
 int EMU_runOther();
 void EMU_copyMasterBuffer();

--- a/Nitrogen/emulator/NitrogenEmulatorViewController.mm
+++ b/Nitrogen/emulator/NitrogenEmulatorViewController.mm
@@ -176,6 +176,7 @@ const float textureVert[] =
     
     EMU_setFrameSkip([defaults integerForKey:@"frameSkip"]);
     EMU_enableSound(![defaults boolForKey:@"disableSound"]);
+    EMU_setSynchMode([defaults boolForKey:@"synchSound"]);
     
     self.directionalControl.style = [defaults integerForKey:@"controlPadStyle"];
     

--- a/Nitrogen/settings/NitrogenSettingsViewController.m
+++ b/Nitrogen/settings/NitrogenSettingsViewController.m
@@ -35,6 +35,9 @@
 @property (weak, nonatomic) IBOutlet UISwitch *showFPSSwitch;
 @property (weak, nonatomic) IBOutlet UISwitch *showPixelGridSwitch;
 
+@property (weak, nonatomic) IBOutlet UILabel *synchSoundLabel;
+@property (weak, nonatomic) IBOutlet UISwitch *synchSoundSwitch;
+
 @property (weak, nonatomic) IBOutlet UISwitch *enableJITSwitch;
 
 @property (weak, nonatomic) IBOutlet UILabel *vibrateLabel;
@@ -166,6 +169,8 @@
         [defaults setInteger:frameSkip forKey:@"frameSkip"];
     } else if (sender == self.disableSoundSwitch) {
         [defaults setBool:self.disableSoundSwitch.on forKey:@"disableSound"];
+    } else if (sender == self.synchSoundSwitch) {
+        [defaults setBool:self.synchSoundSwitch.on forKey:@"synchSound"];
     } else if (sender == self.showPixelGridSwitch) {
         [defaults setBool:self.showPixelGridSwitch.on forKey:@"showPixelGrid"];
     } else if (sender == self.controlPadStyleControl) {
@@ -214,6 +219,7 @@
     
     self.showFPSSwitch.on = [defaults boolForKey:@"showFPS"];
     self.showPixelGridSwitch.on = [defaults boolForKey:@"showPixelGrid"];
+    self.synchSoundSwitch.on = [defaults boolForKey:@"synchSound"];
     
     self.enableJITSwitch.on = [defaults boolForKey:@"enableLightningJIT"];
     self.vibrateSwitch.on = [defaults boolForKey:@"vibrate"];

--- a/Nitrogen/support/Nitrogen-Info.plist
+++ b/Nitrogen/support/Nitrogen-Info.plist
@@ -63,6 +63,8 @@
 	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>MainStoryboard</string>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>UIPrerenderedIcon</key>


### PR DESCRIPTION
-Add “Synchronous Audio” to settings, which helps with games that play
video.
-fix pixel grid for iPhone 6/6+ res so that it fills screen