### PR TITLE
Move defaultsChanged call to viewDidAppear to be after loadROM

### DIFF
--- a/Nitrogen/emulator/NitrogenEmulatorViewController.mm
+++ b/Nitrogen/emulator/NitrogenEmulatorViewController.mm
@@ -137,8 +137,6 @@ const float textureVert[] =
     if ([[GCController controllers] count] > 0) {
         [self controllerActivated:nil];
     }
-    
-    [self defaultsChanged:nil];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -157,6 +155,7 @@ const float textureVert[] =
 {
     [super viewDidAppear:animated];
     [self loadROM];
+    [self defaultsChanged:nil];
 }
 
 - (void)didReceiveMemoryWarning


### PR DESCRIPTION
Fixes #20, #23 

Previously, defaultsChanged was crashing on the call EMU_enableSound as it was being called before the SPU_Core was initialised (as initialisation is done as part of EMU_init, which is performed as part of loadROM). To fix the crash, the initial defaultsChanged call was moved to after the loadROM call in viewDidAppear.

/cc @ReimuHakurei @inb4ohnoes 
